### PR TITLE
Fix contact us button

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -55,7 +55,6 @@ module.exports = {
     },
     'gatsby-plugin-sharp',
     'gatsby-transformer-sharp',
-    `gatsby-plugin-offline`,
     {
       resolve: `gatsby-plugin-nprogress`,
       options: {

--- a/src/components/Button/index.js
+++ b/src/components/Button/index.js
@@ -1,6 +1,6 @@
 import React from "react";
 import Icon from "../Icon/index";
-import Link from "gatsby-link";
+import { Link } from "gatsby"
 import "./styles.scss";
 
 const btnTypes = {

--- a/src/components/Button/index.js
+++ b/src/components/Button/index.js
@@ -42,7 +42,8 @@ export default ({
   type = "default",
   size = "default",
   externalLink,
-  internalLink
+  internalLink,
+  target = "_blank"
 }) => {
   let customClassName = className ? className : "";
   let classes = `button ${btnTypes[type]} ${btnSizes[size]} ${customClassName}`;
@@ -65,7 +66,7 @@ export default ({
       <button className="custom-button">
         <a
           className={classes}
-          target={internalLink ? "_self" : "_blank"}
+          target={target}
           href={externalLink}
         >
           {IconComp()}

--- a/src/pages/contact/index.js
+++ b/src/pages/contact/index.js
@@ -80,6 +80,7 @@ class ContactPage extends Component {
                       size="medium"
                       icon="mail"
                       externalLink="mailto:contact@overture.bio"
+                      target="_self"
                     >
                       Contact Us
                     </Button>

--- a/src/pages/contact/index.js
+++ b/src/pages/contact/index.js
@@ -79,7 +79,7 @@ class ContactPage extends Component {
                       className="my2 mr2"
                       size="medium"
                       icon="mail"
-                      internalLink="mailto:contact@overture.bio"
+                      externalLink="mailto:contact@overture.bio"
                     >
                       Contact Us
                     </Button>


### PR DESCRIPTION
Fix contact-us button (properly opens as a `mailto:` link.