### PR TITLE
Azure documentation fix

### DIFF
--- a/markdown/documentation/score/installation/configuration/profiles.md
+++ b/markdown/documentation/score/installation/configuration/profiles.md
@@ -59,11 +59,7 @@ azure.accountKey="<storage_account_secret_key>"
 
 bucket.name.object="<object_bucket>" # Name of the bucket or container that will store the object data
 bucket.policy.upload="<write_policy>" # Name of the access policy to use for write/add/modify operations
-bucket.policy.downolad="<read_policy>" # Name of the access policy for the read/list operations
-
-upload.partsize=104587
-
-download.partsize=250000000 # Safe default part size for downloads
+bucket.policy.download="<read_policy>" # Name of the access policy for the read/list operations
 
 object.sentinel="heliograph" # Score requires a sample object/file to exist in the object storage for `ping` operations; default is `heliograph`
 ```


### PR DESCRIPTION
- Removed part size configs are they currently do not actually have any effect. 
- Fixed type for `download`