### PR TITLE
Style/#338 support footer resizing

### DIFF
--- a/src/components/SupportFooter/index.js
+++ b/src/components/SupportFooter/index.js
@@ -99,6 +99,34 @@ function SupportFooter({ location }) {
             <p className="support-footer__sub-title">Still need help?</p>
             <Link to={SLACK_LINK}>Ask us on Slack</Link>
           </div>
+          {/* joint column - second and third column*/}
+          <div className="support-footer__joint-second-third-column">
+            <div className="support-footer__joint-second-column">
+              <p className="support-footer__sub-title">Help make our docs better</p>
+              <ul>
+                <li>
+                  <a href={GITHUB_SUBMIT_ISSUES_LINK} target="_blank" rel="noopener noreferrer">
+                    Submit an issue
+                  </a>
+                </li>
+                <li>
+                  <a href={GITHUB_REQUEST_FEATURES_LINK} target="_blank" rel="noopener noreferrer">
+                    Submit a feature request
+                  </a>
+                </li>
+                <li>
+                  <a href={contributionURL} target="_blank" rel="noopener noreferrer">
+                    Make a contribution
+                  </a>
+                </li>
+              </ul>
+            </div>
+            {/* third column - slack link */}
+            <div className="support-footer__joint-third-column">
+              <p className="support-footer__sub-title">Still need help?</p>
+              <Link to={SLACK_LINK}>Ask us on Slack</Link>
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/SupportFooter/styles.scss
+++ b/src/components/SupportFooter/styles.scss
@@ -12,8 +12,7 @@
     margin: 54px auto;
     background-color: $blue-block;
     box-sizing: border-box;
-    max-width: 350px;
-
+    max-width: 100%;
     @include breakpoint(tablet-up) {
       align-items: flex-start;
       max-width: 1147px;

--- a/src/components/SupportFooter/styles.scss
+++ b/src/components/SupportFooter/styles.scss
@@ -26,7 +26,6 @@
     }
 
     @media (min-width: 1161px) {
-      align-items: center;
       max-width: 100%;
     }
 

--- a/src/components/SupportFooter/styles.scss
+++ b/src/components/SupportFooter/styles.scss
@@ -27,10 +27,11 @@
 
     @include breakpoint(navmenu-up) {
       align-items: center;
-      max-width: 350px;
+      max-width: 100%;
     }
 
     @include breakpoint(desktop-ultra-wide) {
+      align-items: flex-start;
       max-width: 1147px;
     }
   }
@@ -61,19 +62,43 @@
     }
 
     @include breakpoint(navmenu-up) {
-      flex-direction: column;
-      max-width: 75%;
+      justify-content: center;
+      max-width: 100%;
     }
 
     @include breakpoint(desktop-ultra-wide) {
       max-width: none;
       flex-direction: row;
+      justify-content: space-between;
+      align-items: flex-start;
     }
 
     > div {
       flex: 1;
       padding: 20px;
       box-sizing: border-box;
+    }
+  }
+
+  &__second-column,
+  &__third-column {
+    @include breakpoint(navmenu-up) {
+      display: none;
+    }
+    @include breakpoint(desktop-ultra-wide) {
+      display: block;
+    }
+  }
+
+  &__joint-second-third-column {
+    display: none;
+    @include breakpoint(navmenu-up) {
+      display: flex;
+      flex-direction: column;
+      gap: 1.6em;
+    }
+    @include breakpoint(desktop-ultra-wide) {
+      display: none;
     }
   }
 

--- a/src/components/SupportFooter/styles.scss
+++ b/src/components/SupportFooter/styles.scss
@@ -25,7 +25,7 @@
       gap: 20px;
     }
 
-    @include breakpoint(navmenu-up) {
+    @media (min-width: 1161px) {
       align-items: center;
       max-width: 100%;
     }
@@ -61,7 +61,7 @@
       align-items: flex-start;
     }
 
-    @include breakpoint(navmenu-up) {
+    @media (min-width: 1161px) {
       justify-content: center;
       max-width: 100%;
     }
@@ -82,7 +82,7 @@
 
   &__second-column,
   &__third-column {
-    @include breakpoint(navmenu-up) {
+    @media (min-width: 1161px) {
       display: none;
     }
     @include breakpoint(desktop-ultra-wide) {
@@ -92,7 +92,7 @@
 
   &__joint-second-third-column {
     display: none;
-    @include breakpoint(navmenu-up) {
+    @media (min-width: 1161px) {
       display: flex;
       flex-direction: column;
       gap: 1.6em;


### PR DESCRIPTION
Update blue box support footer to fill white space around 1162 and 1406px
Update and fixed the odd behaviour css between 1159-1161px

### 1159px
![Screenshot 2023-10-26 at 2 57 20 PM](https://github.com/overture-stack/website/assets/79996555/6ed455ee-dbd5-4de8-af3b-e7f206d85c2f)

### 1160px
![Screenshot 2023-10-26 at 2 57 31 PM](https://github.com/overture-stack/website/assets/79996555/cbedef88-4218-4a82-997f-687f503b09eb)

### 1161px
![Screenshot 2023-10-26 at 2 57 44 PM](https://github.com/overture-stack/website/assets/79996555/fb274860-905d-4f8f-9e86-c24e68fb2207)

### 1406
![Screenshot 2023-10-26 at 2 58 02 PM](https://github.com/overture-stack/website/assets/79996555/fb459a21-5ef2-46b7-9299-b9ed517f64f7)


