### PR TITLE
docs bug fix

### DIFF
--- a/src/components/SectionTableOfContents/index.js
+++ b/src/components/SectionTableOfContents/index.js
@@ -3,58 +3,58 @@ import { useSSRWorkaround } from 'hooks';
 import { Icon, LinkHelper as Link } from 'components';
 import './styles.scss';
 
-const makeUrl = url => `/documentation/${url}/`;
+// Helper function to construct the URL
+const makeUrl = (url) => `/documentation/${url}/`;
 
-const MenuItems = ({ level = 1, pages = [], path }) => {
-  if (!pages.length) return null;
-  const [isOpen, setIsOpen] = useState(null);
-  // when the user closes a parent menu
-  const olClassName = `menu-level-${level}`;
-  const nextLevel = level + 1;
+const MenuItems = ({ level, pages, path }) => {
+  // Initialize isOpen states for all menu items
+  const [openStates, setOpenStates] = useState({});
+
+  // Effect to set initial open states based on the active path
+  useEffect(() => {
+    const initialOpenStates = pages.reduce((states, page) => {
+      const url = makeUrl(page.url);
+      states[url] = page.subpages && path.includes(url);
+      return states;
+    }, {});
+    setOpenStates(initialOpenStates);
+  }, [pages, path]);
+
+  // Function to toggle the open state of a menu item
+  const toggle = (url) => {
+    setOpenStates((prevOpenStates) => ({
+      ...prevOpenStates,
+      [url]: !prevOpenStates[url],
+    }));
+  };
 
   return (
-    <ol className={olClassName}>
-      {pages.map(page => {
-        const { isHeading, pages: subpages, title } = page;
-        const url = makeUrl(page.url);
+    <ol className={`menu-level-${level}`}>
+      {pages.map((page) => {
+        const { isHeading, pages: subpages, title, url: pageUrl } = page;
+        const url = makeUrl(pageUrl);
         const isLinkActive = path === url;
+        const isMenuActive = subpages && path.includes(url);
+        const isOpen = openStates[url];
 
-        // submenus
-        const hasToggle = !!(subpages && !isHeading);
-        const isMenuActive = hasToggle && path.includes(url);
-        const isMenuOpenOnLoad = hasToggle && isOpen === null && isMenuActive;
-        const isMenuOpen = hasToggle && (isMenuOpenOnLoad || isOpen);
-
-        const toggle = () => {
-          setIsOpen(!isMenuOpen);
-        };
-
-        useEffect(() => {
-          if (isMenuActive) setIsOpen(true);
-        }, []);
-
-        const liClassName = `${
-          isHeading ? 'menu-heading' : isMenuActive ? 'menu-active' : isMenuOpen ? 'menu-open' : ''
-        } ${isLinkActive ? 'link-active' : ''}`;
+        const liClassName = `${isHeading ? 'menu-heading' : ''} ${isMenuActive ? 'menu-active' : ''} ${isOpen ? 'menu-open' : ''} ${isLinkActive ? 'link-active' : ''}`;
         const iconImg = isLinkActive ? 'chevronMagenta' : 'chevronGrey';
-        const iconStyle = isMenuOpen ? { transform: 'rotate(90deg)' } : {};
+        const iconStyle = isOpen ? { transform: 'rotate(90deg)' } : {};
 
         return (
           <li key={url} className={liClassName}>
             {isHeading && subpages && <h4>{title}</h4>}
             {!isHeading && !subpages && <Link to={url}>{title}</Link>}
-            {hasToggle && (
-              <React.Fragment>
-                <Link onClick={toggle} to={url} className="menu-toggle-link">
+            {subpages && (
+              <>
+                <Link onClick={() => toggle(url)} to={url} className="menu-toggle-link">
                   {title}
                 </Link>
-                <button className="menu-toggle-btn" onClick={toggle}>
+                <button className="menu-toggle-btn" onClick={() => toggle(url)}>
                   <Icon img={iconImg} size={10} style={iconStyle} />
                 </button>
-              </React.Fragment>
-            )}
-            {(isHeading || isMenuOpen) && (
-              <MenuItems level={nextLevel} pages={subpages} path={path} />
+                {isOpen && <MenuItems level={level + 1} pages={subpages} path={path} />}
+              </>
             )}
           </li>
         );
@@ -65,11 +65,11 @@ const MenuItems = ({ level = 1, pages = [], path }) => {
 
 export default function SectionTableOfContents({ pages, path }) {
   const { key } = useSSRWorkaround();
-  // useSSRWorkaround will force a re-render after the component mounts
+// useSSRWorkaround will force a re-render after the component mounts
   // in order to correctly highlight the active page.
   return (
     <div className="toc-section" key={key}>
-      <MenuItems pages={pages} path={path} />
+      <MenuItems level={1} pages={pages} path={path} />
     </div>
   );
 }


### PR DESCRIPTION
Documentation page loading bug #349

Some documentation pages fail to load when clicking between them from the documentation dropdown.

When running locally, you get this error:

15048 |   if (!!didRenderTooFewHooks) {
  15049 |     {
> 15050 |       throw Error( "Rendered fewer hooks than expected. This may be caused by an accidental early return statement." );
  15051 |     }
  15052 |   }
  15053 | (edited) 
Specifically when clicking between updated docs pages (arranger, DMS-UI and Song)
The issue does not occur when moving between older docs pages (Score, Maestro and Ego) or accessing any pages from the URL.
The error only occurs form the megaNav, mobile menu works as expected

After investigating it I found an instance within the sectiontableofcontents component where **useState** was nested within an if statement.


