### PR TITLE
re-configured docs sidebar items

### DIFF
--- a/markdown/documentation/dms-ui/_contents.yml
+++ b/markdown/documentation/dms-ui/_contents.yml
@@ -3,15 +3,12 @@ sectionTitle: dms-ui
 pages:
 - title: Introduction
   url: dms-ui
-- title: Installation Guide
+- title: Installation
+  url: dms-ui/installation/installation
+- title: Integrations
   url: dms-ui/installation
   isHeading: true
   pages:
-  - title: Installation
-    url: dms-ui/installation/installation
-  - title: Configuration
-    url: dms-ui/installation/configuration
-    pages: 
     - title: Integrating Arranger
       url: dms-ui/installation/configuration/arranger
     - title: Integrating Ego

--- a/markdown/documentation/dms/_contents.yaml
+++ b/markdown/documentation/dms/_contents.yaml
@@ -39,19 +39,15 @@ pages:
     url: dms/installation/test-upload
   - title: Demonstration Videos
     url: dms/installation/demos
-- title: Admin Guide
+- title: User Guide
   url: dms/admin-guide
   isHeading: true
   pages:
+  - title: Using the Data Portal
+    url: dms/user-guide/data-portal
   - title: Admin Tasks
     url: dms/admin-guide/tasks
   - title: Common Problems
     url: dms/admin-guide/common-problems
   - title: Command Reference
     url: dms/admin-guide/commands
-- title: User Guide
-  url: dms/user-guide
-  isHeading: true
-  pages:
-  - title: Using the Data Portal
-    url: dms/user-guide/data-portal

--- a/markdown/documentation/ego/_contents.yaml
+++ b/markdown/documentation/ego/_contents.yaml
@@ -3,8 +3,6 @@ sectionTitle: Ego
 pages:
   - title: Introduction
     url: ego
-  - title: Technical Details
-    url: ego/technical
   - title: Installation Guide
     url: ego/installation
     isHeading: true
@@ -30,6 +28,8 @@ pages:
     url: ego/user-guide
     isHeading: true
     pages:
+      - title: Technical Details
+        url: ego/technical
       - title: Using the Admin UI
         url: ego/user-guide/admin-ui
         pages:

--- a/markdown/documentation/score/_contents.yaml
+++ b/markdown/documentation/score/_contents.yaml
@@ -33,5 +33,5 @@ pages:
     url: score/user-guide/upload
   - title: Downloading Data
     url: score/user-guide/download
-  - title: Command Reference
+  - title: Score-Client Commands
     url: score/user-guide/commands

--- a/markdown/documentation/song/_contents.yaml
+++ b/markdown/documentation/song/_contents.yaml
@@ -35,11 +35,7 @@ pages:
             url: song/user/api/update
       - title: Submitting Data 
         url: song/user/submit
-  - title: Admin Guide 
-    url: song/admin
-    isHeading: true
-    pages:
-      - title: Dynamic Schemas
+      - title: Schema Management
         url: song/admin/schemas
         pages: 
           - title: Making Schemas
@@ -50,9 +46,5 @@ pages:
             url: song/admin/schemas/managingschemas
       - title: Analysis Management
         url: song/admin/analysismanagement
-  - title: Reference
-    url: song/reference
-    isHeading: true
-    pages:
-      - title: Command Reference
+      - title: Song-Client Commands
         url: song/reference/commands

--- a/src/components/NavBar/MegaMenu/index.js
+++ b/src/components/NavBar/MegaMenu/index.js
@@ -66,11 +66,11 @@ const data = {
           },
 
           {
-            to: '/documentation/dms/admin-guide/',
+            to: '/documentation/dms/admin-guide/tasks',
             text: 'For Administrators',
           },
           {
-            to: '/documentation/dms/user-guide/',
+            to: '/documentation/dms/user-guide/data-portal',
             text: 'For Users',
           },
         ],


### PR DESCRIPTION
**Reason for change:** The current documentation sidebar component throws an error when moving from docs pages with differing amounts of sidebar headers ([link original issue](https://github.com/overture-stack/website/issues/349))

**Change made:** To temporarily fix this issue, I configured each documentation page with three header items; we will work on refactoring the docs sidebar during the next set of website updates  (Overture playground update).