### PR TITLE
Docker Song and Score client setup with docker exec commands

### DIFF
--- a/markdown/documentation/score/user-guide/client-setup.md
+++ b/markdown/documentation/score/user-guide/client-setup.md
@@ -13,9 +13,9 @@ You must supply environment variables for the STORAGE_URL, the METADATA_URL and 
 ```bash
 docker run -d -it \
 --name score-client \
--e ACCESSTOKEN=${token} \
--e STORAGE_URL=http://<INSERT-URL>/score-api \
--e METADATA_URL=http://<INSERT-URL>/song-api \
+-e CLIENT_ACCESS_TOKEN=${token} \
+-e STORAGE_URL=http://<INSERT-URL> \
+-e METADATA_URL=http://<INSERT-URL> \
 --network="host" \
 --mount type=bind,source="$(pwd)",target=/output \
 ghcr.io/overture-stack/score:latest

--- a/markdown/documentation/score/user-guide/commands.md
+++ b/markdown/documentation/score/user-guide/commands.md
@@ -9,7 +9,7 @@ Invoke a command by running the `score-client` executable and appending the nece
 For instance, to use the `upload` command with the `--manifest` option:
 
 ```BASH
-./score-client-<latest-release-number>/bin/score-client upload --manifest ./<directory>/manifest.txt
+docker exec score-client sh -c "./score-client-<latest-release-number>/bin/score-client upload --manifest ./<directory>/manifest.txt"
 ```
 
 # Commands

--- a/markdown/documentation/score/user-guide/commands.md
+++ b/markdown/documentation/score/user-guide/commands.md
@@ -61,7 +61,7 @@ The `manifest` command shows entries of a specific Score manifest file. It can b
 
 ## Mount
 
-The `mount` command is a read-only <a href="https://github.com/libfuse/" target="_blank" rel="noopener noreferrer">FUSE</a> filesystem view of the object storage repository in use by Score. This command can be used with the following option flags:
+The `mount` command is a read-only <a href="https://github.com/libfuse/" target="_blank" rel="noopener noreferrer">FUSE</a> filesystem view of the object storage repository in use by Score, and it can be used with the following optional flags:
 
 | Option | Description |
 | -------| ------------|

--- a/markdown/documentation/score/user-guide/commands.md
+++ b/markdown/documentation/score/user-guide/commands.md
@@ -9,7 +9,7 @@ Invoke a command by running the `score-client` executable and appending the nece
 For instance, to use the `upload` command with the `--manifest` option:
 
 ```BASH
-docker exec score-client sh -c "./score-client-<latest-release-number>/bin/score-client upload --manifest ./<directory>/manifest.txt"
+docker exec score-client sh -c "score-client upload --manifest ./<directory>/manifest.txt"
 ```
 
 # Commands
@@ -18,7 +18,7 @@ The sections below provide a reference for all commands and their respective opt
 
 ## Download
 
-Retrieve file object(s) from the remote storage repository.
+The `download` command is used to retrieve file object(s) from the remote storage repository and can be used with the following option flags:
 
 | Option | Description |
 | -------| ------------|
@@ -41,11 +41,11 @@ Retrieve file object(s) from the remote storage repository.
 
 ## Help
 
-Displays detailed information about Score client commands and their options.
+The `help` command can be used to display detailed information about Score client commands and their options.
 
 ## Info
 
-Presents the active configuration details of the Score client.
+The `info` command shows the active configuration details of the Score client. It can be used with the following option flag:
 
 | Option | Description |
 | -------| ------------|
@@ -53,7 +53,7 @@ Presents the active configuration details of the Score client.
 
 ## Manifest
 
-Show the entries of a specific Score manifest file.
+The `manifest` command shows entries of a specific Score manifest file. It can be used with the following option flag:
 
 | Option | Description |
 | -------| ------------|
@@ -61,7 +61,7 @@ Show the entries of a specific Score manifest file.
 
 ## Mount
 
-Mount a read-only <a href="https://github.com/libfuse/" target="_blank" rel="noopener noreferrer">FUSE</a> filesystem view of the object storage repository in use by Score.
+The `mount` command is a read-only <a href="https://github.com/libfuse/" target="_blank" rel="noopener noreferrer">FUSE</a> filesystem view of the object storage repository in use by Score. This command can be used with the following option flags:
 
 | Option | Description |
 | -------| ------------|
@@ -77,7 +77,7 @@ Mount a read-only <a href="https://github.com/libfuse/" target="_blank" rel="noo
 
 ## Upload
 
-Send file object(s) to the remote storage repository.
+The `upload` command sends file object(s) to the remote storage repository. It can be used with the following option flags:
 
 
 | Option | Description |
@@ -92,7 +92,7 @@ Send file object(s) to the remote storage repository.
 
 ## Url
 
-Reveal the URL of a specific file object in the object storage repository.
+The `url` command reveals the URL of a specific file object in the object storage repository. It is used with the following option flag:
 
 | Option | Description |
 | -------| ------------|
@@ -100,11 +100,11 @@ Reveal the URL of a specific file object in the object storage repository.
 
 ## Version
 
-Provide the current version details of the Score client.
+The `version` command provides the current version details of the Score client.
 
 ## View
 
-Store locally and showcase parts or the entirety of a <a href="https://samtools.github.io/hts-specs/SAMv1.pdf" target="_blank" rel="noopener noreferrer">SAM or BAM</a> file.
+The `view` command stores locally and showcases a <a href="https://samtools.github.io/hts-specs/SAMv1.pdf" target="_blank" rel="noopener noreferrer">SAM or BAM</a> file. It can be used with the following option flags:
 
 | Option | Description |
 | -------| ------------|

--- a/markdown/documentation/score/user-guide/download.md
+++ b/markdown/documentation/score/user-guide/download.md
@@ -41,7 +41,7 @@ Here is an example of downloading files using a previously generated manifest fi
 Execute the following command from your home directory:
 
 ```shell
-./score-client-<latest-release-number>/bin/score-client download --manifest ./<manifestDirectory>/manifest.txt --output-dir ./<outputDirectory>
+docker exec score-client sh -c "score-client download --manifest ./<manifestDirectory>/manifest.txt --output-dir ./<outputDirectory>"
 ```
 
 -  `<manifestDirectory>` represents the location of the earlier generated manifest file

--- a/markdown/documentation/score/user-guide/upload.md
+++ b/markdown/documentation/score/user-guide/upload.md
@@ -30,7 +30,7 @@ Here's a step-by-step guide to uploading files using a previously created manife
 1. Execute the following command from your home directory:
 
 ```bash
-docker exec score-client sh -c "./score-client-<latest-release-number>/bin/score-client upload --manifest ./<directory>/manifest.txt"
+docker exec score-client sh -c "score-client upload --manifest ./<directory>/manifest.txt"
 ```
 
 Replace `<directory>` with the location of the previously created manifest file.

--- a/markdown/documentation/score/user-guide/upload.md
+++ b/markdown/documentation/score/user-guide/upload.md
@@ -30,10 +30,10 @@ Here's a step-by-step guide to uploading files using a previously created manife
 1. Execute the following command from your home directory:
 
 ```bash
-./score-client-<latest-release-number>/bin/score-client upload --manifest ./<directory>/manifest.txt
+docker exec score-client sh -c "./score-client-<latest-release-number>/bin/score-client upload --manifest ./<directory>/manifest.txt"
 ```
 
-Replace `<directory>` with the location of the previously-created manifest file.
+Replace `<directory>` with the location of the previously created manifest file.
 
 <Note title="What is a Manifest?">To understand more about key terms in Overture's data submission workflow, check this guide on [data submission using Song and Score.](/documentation/song/user/submit/)</Note>
 

--- a/markdown/documentation/song/reference/commands.md
+++ b/markdown/documentation/song/reference/commands.md
@@ -7,7 +7,7 @@ To invoke a command, run the `song-client` executable and append any options req
 For information on the available commands, use the following:
 
 ```shell
-song-client-5.0.2/bin/sing --help
+docker exec song-client sh -c "sing --help"
 ```
 
 The following is provided as a reference to all the commands and command options currently supported by the Song client.

--- a/markdown/documentation/song/user/submit.md
+++ b/markdown/documentation/song/user/submit.md
@@ -10,31 +10,30 @@ Submitted data consists of data files (e.g. sequencing reads or VCFs), as well a
 
 **Running the song-client docker image** 
 
-You must supply environment variables for the `CLIENT_STUDY_ID`, the `CLIENT_SERVER_URL` and your `ACCESSTOKEN`. The access token is supplied from Ego or your profile page within the DMS-UI.
+You must supply environment variables for the `CLIENT_STUDY_ID`, the `CLIENT_SERVER_URL` and your `CLIENT_ACCESS_TOKEN`. The access token is supplied from Ego or your profile page within the DMS-UI.
 
 ```bash
 docker run -d -it --name song-client \
--e ACCESSTOKEN=${token} \
+-e CLIENT_ACCESS_TOKEN=${token} \
 -e CLIENT_STUDY_ID=ABC123 \
--e CLIENT_SERVER_URL=http://<INSERT-URL>/song-api \
+-e CLIENT_SERVER_URL=https://<INSERT-URL> \
 --network="host" \
 --mount type=bind,source="$(pwd)",target=/output \
 ghcr.io/overture-stack/song-client:latest
 ```
 
-
 # Installing the Score-Client
 
 **Running the score-client docker image** 
 
-You will be required to supply environment variables for the `STORAGE_URL`, the `METADATA_URL` and your `ACCESSTOKEN`.
+You will be required to supply environment variables for the `STORAGE_URL`, the `METADATA_URL` and your `CLIENT_ACCESS_TOKEN`.
 
 ```bash
 docker run -d -it \
 --name score-client \
--e ACCESSTOKEN=${token} \
--e STORAGE_URL=http://<INSERT-URL>/score-api \
--e METADATA_URL=http://<INSERT-URL>/song-api \
+-e CLIENT_ACCESS_TOKEN=${token} \
+-e STORAGE_URL=http://<INSERT-URL> \
+-e METADATA_URL=http://<INSERT-URL> \
 --network="host" \
 --mount type=bind,source="$(pwd)",target=/output \
 ghcr.io/overture-stack/score:latest
@@ -51,7 +50,7 @@ First, a metadata payload must be prepared. The payload must conform to an `anal
 Once you have formatted the payload correctly, use the song-client `submit` command to upload the payload.
 
 ```bash 
-./bin/sing submit -f example-payload.json
+docker exec song-client sh -c "sing submit -f /output/example-payload.json"
 ```
 
 If your payload is not formatted correctly, you will receive an error message detailing what is wrong. Please fix any errors and resubmit. If your payload is formatted correctly, you will get an `analysisId` in response:
@@ -65,7 +64,7 @@ If your payload is not formatted correctly, you will receive an error message de
 
 At this point, since the payload data has successfully been submitted and accepted by Song, it is now referred to as an analysis. By default, all newly created analyses are set to an `UNPUBLISHED` state.
 
-<Warning>For more information on analysis states (published, unpublished and suppressed) see our page on [analysis managment](/documentation/song/admin/analysismanagement/)</Warning>
+<Warning>For more information on analysis states (published, unpublished and suppressed) see our page on [analysis management](/documentation/song/admin/analysismanagement/)</Warning>
 
 ## Step 3. Generate a manifest file
 
@@ -75,14 +74,14 @@ The manifest establishes a link between the analysis-id that has been submitted 
 
 Using the song-client `manifest` command, define
 
-- The analysis id using `-a` parameter
+- The analysis id using the `-a` parameter
 - The location of your input files with the `-d` parameter
 - The output file path for the manifest file with the `-f` parameter. **Note**: this is a *file path* not a directory path
 
 Here is an example of a manifest command:
 
 ```bash
-./bin/sing manifest -a a4142a01-1274-45b4-942a-01127465b422 -f /some/output/dir/manifest.txt  -d /submitting/file/directory
+docker exec song-client sh -c "sing manifest -a a4142a01-1274-45b4-942a-01127465b422 -f /some/output/dir/manifest.txt  -d /submitting/file/directory"
 ```
 
 Here is the expected response:
@@ -98,7 +97,7 @@ The `manifest.txt` file will be written out to a defined output file path. If th
 Upload all the files associated with the analysis using the score-client `upload` command:
 
 ```bash
-.bin/score-client  upload --manifest manifest.txt
+docker exec score-client sh -c "score-client  upload --manifest manifest.txt"
 ```
 
 Once the file(s) successfully upload, you will receive an `Upload completed` message.
@@ -110,7 +109,7 @@ Once the file(s) successfully upload, you will receive an `Upload completed` mes
 Sometimes, if an upload is stuck, you can reinitiate the upload using the `--force` command. 
 
 ```bash
-.bin/score-client  upload --manifest manifest.txt --force 
+docker exec score-client sh -c "score-client  upload --manifest manifest.txt --force "
 ```
 For more information on Score, please see the <a href="/documentation/score" target="_blank" rel="noopener noreferrer">Score documentation page</a>.
 
@@ -119,7 +118,7 @@ For more information on Score, please see the <a href="/documentation/score" tar
 The final step to submitting molecular data is to set the state of an analysis to `PUBLISHED`. A published analysis signals to the data administrators that this data is ready to be processed by downstream services.
 
 ```bash
-./bin/sing publish -a a4142a01-1274-45b4-942a-01127465b422
+docker exec song-client sh -c "sing publish -a a4142a01-1274-45b4-942a-01127465b422"
 ```
 
 Here is the expected response:
@@ -128,6 +127,6 @@ Here is the expected response:
 AnalysisId a4142a01-1274-45b4-942a-01127465b422 successfully published
 ```
 
-A published analysis will now be searchable in Song. In the next section we will outline how to search for data in Song.
+A published analysis will now be searchable in Song. In the next section, we will outline how to search for data in Song.
 
-<Note title="Integration Tips">Song is a relational database designed for secure and consistent storage of data.  For an optimal data query experience, use song with a search platform.  The Overture components [Maestro](/documentation/maestro) and [Arranger](/documentation/arranger) can be used to index and view data from Song from an intuitive search portal linked to a graphQL API.</Note>
+<Note title="Integration Tips">Song is a relational database designed for secure and consistent storage of data.  For an optimal data query experience, use Song with a search platform.  The Overture components [Maestro](/documentation/maestro) and [Arranger](/documentation/arranger) can be used to index and view data from Song from an intuitive search portal linked to a graphQL API.</Note>


### PR DESCRIPTION
Updated environment variables to appropriately match those outlined in following files:

- https://github.com/overture-stack/SONG/blob/develop/song-client/src/main/resources/application.yml
- https://github.com/overture-stack/SCORE/blob/develop/score-client/src/main/resources/application.yml

Updated all commands with the following formatting `docker exec {container/client} sh -c "{command}"`

Question for Dev Team - Why is our score-client container called `score`? Can we update this to score-client?
