### PR TITLE
Bridge website update

### DIFF
--- a/constants/external-links.js
+++ b/constants/external-links.js
@@ -1,21 +1,32 @@
+// Overture Docs + Demo
+
 export const DEMO_LINK = 'https://demo.overture.bio/';
-export const DOCKER_DOWNLOAD =
-  'https://www.docker.com/products/docker-desktop/';
+export const DOCUMENTATION_LINK = 'https://main--overturedev.netlify.app/';
+export const OVERTURE_GITHUB_LINK = 'https://github.com/overture-stack/';
+export const OVERTURE_DOCUMENTATION_CONTRIBUTION_LINK =
+  'https://main--overturedev.netlify.app/community/contribution';
+export const OVERTURE_GITHUB_DISSCUSSION_LINK =
+  'https://github.com/overture-stack/docs/discussions';
+export const OVERTURE_DOCUMENTATION_SUPPORT_LINK =
+  'https://main--overturedev.netlify.app/community/support';
 export const FEATURE_REQUESTS =
   'https://github.com/overture-stack/website/issues/new?assignees=&labels=&projects=&template=Feature_Requests.md';
+export const USER_GUIDES =
+  'https://main--overturedev.netlify.app/guides/user-guides/';
+export const ADMINISTRATION_GUIDES =
+  'https://main--overturedev.netlify.app/guides/administration-guides/';
+export const DEPLOYMENT_GUIDES =
+  'https://main--overturedev.netlify.app/guides/deployment-guide/';
+export const API_REFERENCE_GUIDE =
+  'https://main--overturedev.netlify.app/guides/api-reference';
+export const OVERTURE_DOCUMENTATION_CORE_SOFTWARE =
+  'https://main--overturedev.netlify.app/docs/core-software/';
+export const OVERTURE_DOCUMENTATION_UNDER_DEVELOPMENT =
+  'https://main--overturedev.netlify.app/docs/under-development/';
 
-export const ICGC_ARGO_LINK = 'https://www.icgc-argo.org/';
-export const ICGC_ARGO_PORTAL_LINK = 'https://platform.icgc-argo.org/';
-export const CGC_LINK = 'https://cancercollaboratory.org/';
-export const FAQ_LINK =
-  'https://oicr.on.ca/information-practices-frequently-asked-questions/';
+// Case Study Links
+
 export const GDC_LINK = 'https://portal.gdc.cancer.gov/';
-export const OVERTURE_GITHUB_LINK = 'https://github.com/overture-stack/';
-export const GITHUB_ISSUES_LINK = `${OVERTURE_GITHUB_LINK}roadmap/issues`;
-export const GITHUB_SUBMIT_ISSUES_LINK =
-  'https://github.com/overture-stack/website/issues/new?assignees=&labels=bug&projects=&template=bug_report.md&title=BUG+-+';
-export const GITHUB_REQUEST_FEATURES_LINK =
-  'https://github.com/overture-stack/website/issues/new?assignees=&labels=new-feature&projects=&template=Feature_Request.md&title=Feature+Request+';
 export const HCMIS_LINK = 'https://hcmi-searchable-catalog.nci.nih.gov/';
 export const HCMIS_PORTAL_LINK = 'https://hcmi-searchable-catalog.nci.nih.gov/';
 export const ICGC_LINK = 'https://dcc.icgc.org/';
@@ -23,26 +34,32 @@ export const IHCC_LINK = 'https://ihccglobal.org/';
 export const IHCC_PORTAL_LINK = 'https://atlas.ihccglobal.org/';
 export const KIDS_FIRST_LINK =
   'https://portal.kidsfirstdrc.org/login?redirect_path=/dashboard?';
+export const VIRUSSEQ_LINK =
+  'https://genomecanada.ca/challenge-areas/cancogen/virusseq/';
+export const VIRUSSEQ_PORTAL_LINK = 'https://virusseq-dataportal.ca/explorer';
+export const ICGC_ARGO_LINK = 'https://www.icgc-argo.org/';
+export const ICGC_ARGO_PORTAL_LINK = 'https://platform.icgc-argo.org/';
+export const CGC_LINK = 'https://cancercollaboratory.org/';
+
+// Misc Links
+
+export const DOCKER_DOWNLOAD =
+  'https://www.docker.com/products/docker-desktop/';
 export const NETLIFY_IMAGE_LINK =
   'https://www.netlify.com/img/global/badges/netlify-color-bg.svg';
 export const NETLIFY_LINK = 'https://www.netlify.com/';
 export const OICR_LINK = 'https://oicr.on.ca';
-export const OVERTURE_YOUTUBE_LINK =
-  'https://www.youtube.com/embed/NrgL8vpFm5s';
 export const POLICIES_LINK = 'https://oicr.on.ca/oicr-policies-and-procedures/';
 export const PRIVACY_EMAIL_LINK = 'mailto:privacy@oicr.on.ca';
-export const SLACK_LINK =
-  'https://join.slack.com/t/overture-bio/shared_invite/zt-21tdumtdh-9fP1TFeLepK4~Lc377rOYw';
 export const TEAM_BLOG_LINK = 'https://softeng.oicr.on.ca/';
 export const TEAM_LINK = 'https://softeng.oicr.on.ca/team/';
-export const VIRUSSEQ_LINK =
-  'https://genomecanada.ca/challenge-areas/cancogen/virusseq/';
-export const VIRUSSEQ_PORTAL_LINK = 'https://virusseq-dataportal.ca/explorer';
 export const EMAIL_LINK = 'mailto:contact@overture.bio';
 export const GI_PROGRAM_LINK =
   'https://oicr.on.ca/programs/genome-informatics/';
+export const FAQ_LINK =
+  'https://oicr.on.ca/information-practices-frequently-asked-questions/';
 
-// PRODUCTS LINKS
+// Product Links
 
 // arranger
 export const ARRANGER_GETTING_STARTED_LINK =
@@ -53,9 +70,7 @@ export const ARRANGER_UPDATES_LINK =
 export const ARRANGER_GITHUB_LINK =
   'https://github.com/overture-stack/arranger';
 
-// DMS
-export const DMS_RELEASE_NOTES = `${OVERTURE_GITHUB_LINK}dms/releases`;
-export const CANARIE_LINK = 'https://www.canarie.ca/';
+// stage
 export const STAGE_GITHUB_LINK = 'https://github.com/overture-stack/stage';
 
 // ego
@@ -63,31 +78,10 @@ export const EGO_SQL_LINK = `${OVERTURE_GITHUB_LINK}ego/blob/develop/src/main/re
 export const EGO_UPDATES_LINK = 'https://www.overture.bio/documentation/ego/';
 export const EGO_GITHUB_LINK = 'https://github.com/overture-stack/ego';
 
-// jukebox
-export const JUKEBOX_BLOG_POST_LINK =
-  'http://softeng.oicr.on.ca/kevin_hartmann/2018/03/28/Drops-of-Jupyter/';
-export const JUPYTER_LINK = 'https://jupyter.org/index.html';
-export const JUPYTER_INSTALL_LINK = 'https://jupyter.org/install.html';
-
-// oncojs
-export const LOLLIPLOT_EXAMPLE_LINK =
-  'https://portal.gdc.cancer.gov/genes/ENSG00000183914';
-export const ONCOGRID_EXAMPLE_LINK =
-  'https://dcc.icgc.org/analysis/view/oncogrid/ce6fd9fd-b76e-488d-88a5-93bdc690f79e';
-export const SURVIVALPLOT_EXAMPLE_LINK =
-  'https://dcc.icgc.org/analysis/view/phenotype/15c7c81a-7717-49e3-a0f7-be09fdc400b6';
-export const PATHWAYVIEWER_EXAMPLE_LINK =
-  'https://dcc.icgc.org/genesets/R-HSA-1236974/pathway-viewer';
-export const ONCOJS_GITHUB_LINK = 'https://github.com/oncojs';
-
 // maestro
 export const MAESTRO_UPDATES_LINK =
   'https://www.overture.bio/documentation/maestro/';
 export const MAESTRO_GITHUB_LINK = 'https://github.com/overture-stack/maestro';
-
-// persona
-export const PERSONA_LOCAL_LINK = 'http://localhost:3232/graphql';
-export const PERSONA_ENV_SCHEMA_LINK = `${OVERTURE_GITHUB_LINK}persona/blob/master/.env.schema`;
 
 // song
 export const SONG_DOCS_LINK = 'https://www.overture.bio/documentation/song/';

--- a/constants/external-links.js
+++ b/constants/external-links.js
@@ -1,28 +1,27 @@
 // Overture Docs + Demo
 
 export const DEMO_LINK = 'https://demo.overture.bio/';
-export const DOCUMENTATION_LINK = 'https://main--overturedev.netlify.app/';
+export const DOCUMENTATION_LINK = 'https://docs.overture.bio/';
 export const OVERTURE_GITHUB_LINK = 'https://github.com/overture-stack/';
 export const OVERTURE_DOCUMENTATION_CONTRIBUTION_LINK =
-  'https://main--overturedev.netlify.app/community/contribution';
+  'https://docs.overture.bio/community/contribution';
 export const OVERTURE_GITHUB_DISSCUSSION_LINK =
   'https://github.com/overture-stack/docs/discussions';
 export const OVERTURE_DOCUMENTATION_SUPPORT_LINK =
-  'https://main--overturedev.netlify.app/community/support';
+  'https://docs.overture.bio/community/support';
 export const FEATURE_REQUESTS =
   'https://github.com/overture-stack/website/issues/new?assignees=&labels=&projects=&template=Feature_Requests.md';
-export const USER_GUIDES =
-  'https://main--overturedev.netlify.app/guides/user-guides/';
+export const USER_GUIDES = 'https://docs.overture.bio/guides/user-guides/';
 export const ADMINISTRATION_GUIDES =
-  'https://main--overturedev.netlify.app/guides/administration-guides/';
+  'https://docs.overture.bio/guides/administration-guides/';
 export const DEPLOYMENT_GUIDES =
-  'https://main--overturedev.netlify.app/guides/deployment-guide/';
+  'https://docs.overture.bio/guides/deployment-guide/';
 export const API_REFERENCE_GUIDE =
-  'https://main--overturedev.netlify.app/guides/api-reference';
+  'https://docs.overture.bio/guides/api-reference';
 export const OVERTURE_DOCUMENTATION_CORE_SOFTWARE =
-  'https://main--overturedev.netlify.app/docs/core-software/';
+  'https://docs.overture.bio/docs/core-software/';
 export const OVERTURE_DOCUMENTATION_UNDER_DEVELOPMENT =
-  'https://main--overturedev.netlify.app/docs/under-development/';
+  'https://docs.overture.bio/docs/under-development/';
 
 // Case Study Links
 

--- a/constants/pages.js
+++ b/constants/pages.js
@@ -3,7 +3,6 @@ import { internalUrlJoin } from '../utils';
 export const ABOUT_US_PATH = '/about-us/';
 export const ACKNOWLEDGEMENTS_PATH = '/acknowledgements/';
 export const CASE_STUDIES_PATH = '/case-studies/';
-export const CONTACT_US_PATH = '/contact-us/';
 export const COMMUNITY_PATH = '/community/';
 export const GETTING_STARTED_PATH = '/getting-started/';
 export const PRIVACY_PATH = '/privacy/';

--- a/constants/products.js
+++ b/constants/products.js
@@ -1,7 +1,7 @@
 import urlJoin from 'proper-url-join';
 import { internalUrlJoin } from '../utils';
 import { PRODUCTS_PATH } from './pages';
-import { ONCOJS_GITHUB_LINK, OVERTURE_GITHUB_LINK } from './external-links';
+import { OVERTURE_GITHUB_LINK } from './external-links';
 
 // products info that is created or accessed programmatically
 // for other external link constants use external-links.js
@@ -43,7 +43,6 @@ const productsObj = {
     title: 'Maestro',
   },
   oncojs: {
-    githubUrl: ONCOJS_GITHUB_LINK,
     iconWhite: 'productOncoWhite',
     title: 'OncoJS',
   },

--- a/markdown/documentation/guides/download/clientdownload.md
+++ b/markdown/documentation/guides/download/clientdownload.md
@@ -103,7 +103,7 @@ docker run -d -it --name score-client \
 Add the manifest to the `./guideMaterials/dataDownload` folder in your QuickStart repository. For simplicity, update its name to manifest.tsv. After moving and renaming the manifest, you can run the provided command:
 
 ```bash
-docker exec score-client sh -c "score-client download --manifest /output/manifest.tsv --output-dir /output""
+docker exec score-client sh -c "score-client download --manifest /output/manifest.tsv --output-dir /output"
 ```
 
 

--- a/src/components/AnchorHeading/index.js
+++ b/src/components/AnchorHeading/index.js
@@ -2,7 +2,13 @@ import React from 'react';
 import { GoLink as LinkIcon } from 'react-icons/go';
 import { LinkHelper as Link } from 'components';
 
-export default function AnchorHeading({ children, id, location, size: H, ...props }) {
+export default function AnchorHeading({
+  children,
+  id,
+  location,
+  size: H,
+  ...props
+}) {
   return (
     <H {...props} id={id}>
       {/* need ID for the table of contents sidebar in docs section*/}

--- a/src/components/NavBar/index.js
+++ b/src/components/NavBar/index.js
@@ -3,8 +3,6 @@
  * subcomponents: MegaMenu and NavLink
  */
 import React, { Component } from 'react';
-import MegaMenu from './MegaMenu';
-import MegaMenuLink from './MegaMenuLink';
 import NavLink from './NavLink';
 import { Button, LinkHelper as Link } from 'components';
 import {
@@ -15,20 +13,18 @@ import {
   PRODUCTS_PATH,
   SERVICES_PATH,
 } from 'constants/pages';
-import { SLACK_LINK } from 'constants/external-links';
+import { SDOCUMENTATION_LINK } from 'constants/external-links';
 import logo from './assets/overture_logo.svg';
 import './styles.scss';
+import {
+  DOCUMENTATION_LINK,
+  OVERTURE_GITHUB_LINK,
+} from '../../../constants/external-links';
 
 class NavBar extends Component {
   render() {
-    const {
-      closeMenus,
-      megaMenuType,
-      mobileMenuOpen,
-      path,
-      toggleMegaMenu,
-      toggleMobileMenu,
-    } = this.props;
+    const { closeMenus, megaMenuType, mobileMenuOpen, toggleMobileMenu } =
+      this.props;
 
     let mobileMenuClass = mobileMenuOpen ? 'is-active' : '';
     let navbarMenuClass = `navbar-menu ${mobileMenuClass}`;
@@ -65,24 +61,11 @@ class NavBar extends Component {
                 url={PRODUCTS_PATH}
                 name="Products"
               />
-              <MegaMenuLink
-                isActive={megaMenuType === 'documentation'}
-                name="Documentation"
-                path={path}
-                toggleMegaMenu={toggleMegaMenu}
-                type="documentation"
-              >
-                <div ref={(ref) => (this.popoverRef = ref)}>
-                  {mobileMegaCheck && (
-                    <MegaMenu
-                      className="open"
-                      closeMenus={closeMenus}
-                      megaMenuType="documentation"
-                      path={path}
-                    />
-                  )}
-                </div>
-              </MegaMenuLink>
+              <NavLink
+                closeMenus={closeMenus}
+                url={DOCUMENTATION_LINK}
+                name="Guides & Docs"
+              />
               <NavLink
                 closeMenus={closeMenus}
                 url={CASE_STUDIES_PATH}
@@ -101,22 +84,17 @@ class NavBar extends Component {
               />
             </div>
             {/* grey section with three cubes */}
-            <div
-              className={`navbar-mid bg-grey ${
-                megaMenuType === 'documentation' ? 'is-active' : ''
-              }`}
-            ></div>
             <div className="navbar-end ">
               <div className="navbar-item nav-link navbar-buttons">
                 <Button
+                  link={OVERTURE_GITHUB_LINK}
                   iconAlt="slack logo"
-                  className="slack-button"
-                  icon="slackNew"
-                  link={SLACK_LINK}
-                  size="navSlack"
+                  className="github-button"
+                  icon="githubMagenta"
+                  size="large"
                   type="secondary"
                 >
-                  Join us on Slack
+                  Check us out on GitHub
                 </Button>
 
                 <Button

--- a/src/components/NavBar/index.js
+++ b/src/components/NavBar/index.js
@@ -13,7 +13,6 @@ import {
   PRODUCTS_PATH,
   SERVICES_PATH,
 } from 'constants/pages';
-import { SDOCUMENTATION_LINK } from 'constants/external-links';
 import logo from './assets/overture_logo.svg';
 import './styles.scss';
 import {
@@ -64,7 +63,7 @@ class NavBar extends Component {
               <NavLink
                 closeMenus={closeMenus}
                 url={DOCUMENTATION_LINK}
-                name="Guides & Docs"
+                name="Documentation"
               />
               <NavLink
                 closeMenus={closeMenus}

--- a/src/components/NavBar/styles.scss
+++ b/src/components/NavBar/styles.scss
@@ -134,7 +134,7 @@
     }
   }
 
-  .slack-button {
+  .github-button {
     margin-right: 1rem;
     background: $grey-2;
 
@@ -152,9 +152,9 @@
     @include breakpoint(navmenu-below) {
       gap: 3em;
     }
-    .slack-button {
+    .github-button {
       font-size: 1rem;
-      font-weight: 500;
+      font-weight: 600;
     }
 
     @media (max-width: 400px) {
@@ -162,7 +162,7 @@
       justify-content: flex-start;
       gap: 0;
 
-      .slack-button {
+      .github-button {
         margin: 0.5rem;
       }
     }

--- a/src/components/ProductsPageSection/index.js
+++ b/src/components/ProductsPageSection/index.js
@@ -29,7 +29,7 @@ export default function ProductPageSection({
   const desktopWideViewPort = isBrowser && 1215 < width && width <= 1407;
   const desktopUltraWideViewPort = isBrowser && 1408 < width;
 
-  const userDocsLink = `https://overture.bio/documentation/${title.toLowerCase()}`;
+  const userDocsLink = `https://docs.overture.bio/docs/core-software/${title.toLowerCase()}/overview/`;
   const gitHubLink = `https://github.com/overture-stack/${title}`;
 
   return (

--- a/src/components/ServicesPageSection/index.js
+++ b/src/components/ServicesPageSection/index.js
@@ -1,5 +1,8 @@
 import React from 'react';
-import { SLACK_LINK, EMAIL_LINK } from '../../../constants/external-links';
+import {
+  EMAIL_LINK,
+  OVERTURE_DOCUMENTATION_SUPPORT_LINK,
+} from '../../../constants/external-links';
 import { Button, P1, H2 } from 'components';
 import './styles.scss';
 
@@ -47,7 +50,7 @@ const ServicesPageSection = ({
             {buttonText && (
               <div className="ServicesPageSection__button-holder">
                 <Button
-                  link={EMAIL_LINK}
+                  link={OVERTURE_DOCUMENTATION_SUPPORT_LINK}
                   type="primary"
                   size="medium"
                   className="ServicesPageSection__button"

--- a/src/components/SupportFooter/index.js
+++ b/src/components/SupportFooter/index.js
@@ -4,7 +4,10 @@ import { LinkHelper as Link } from 'components';
 import {
   GITHUB_REQUEST_FEATURES_LINK,
   GITHUB_SUBMIT_ISSUES_LINK,
-  SLACK_LINK,
+  OVERTURE_DOCUMENTATION_CONTRIBUTION_LINK,
+  OVERTURE_DOCUMENTATION_SUPPORT_LINK,
+  OVERTURE_GITHUB_DISSCUSSION_LINK,
+  OVERTURE_GITHUB_LINK,
 } from '../../../constants/external-links';
 import urlJoin from 'proper-url-join';
 import smileyFace from './assets/smileyFace.svg';
@@ -26,7 +29,8 @@ function SupportFooter({ location }) {
    */
   function getContributionURL() {
     // Base URL prefix for GitHub repository links (updated to main)
-    const githubPrefix = 'https://github.com/overture-stack/website/tree/main/markdown';
+    const githubPrefix =
+      'https://github.com/overture-stack/website/tree/main/markdown';
     // Extract the pathname from the current location object
     const url = location.pathname;
 
@@ -48,9 +52,11 @@ function SupportFooter({ location }) {
       /*
        * The rest is logic for handling paths unique paths where the url points to an index.md file in the relevant directory.
        */
-      case url.includes('song') && (url.endsWith('schemas/') || url.endsWith('api/')):
+      case url.includes('song') &&
+        (url.endsWith('schemas/') || url.endsWith('api/')):
       case url.includes('maestro') && url.endsWith('user-guide/'):
-      case url.includes('ego') && (url.endsWith('prerequisites/') || url.endsWith('admin-ui/')):
+      case url.includes('ego') &&
+        (url.endsWith('prerequisites/') || url.endsWith('admin-ui/')):
         return urlJoin(githubPrefix, url, 'index.md');
 
       /*
@@ -75,7 +81,9 @@ function SupportFooter({ location }) {
             <div className="feedback-buttons-holder">
               <button
                 onClick={() => handleFeedbackClick(true)}
-                className={`feedback-button ${feedback === true && 'icon-inverted'}`}
+                className={`feedback-button ${
+                  feedback === true && 'icon-inverted'
+                }`}
                 aria-label="Positive feedback"
                 id="postive-feedback"
               >
@@ -83,7 +91,9 @@ function SupportFooter({ location }) {
               </button>
               <button
                 onClick={() => handleFeedbackClick(false)}
-                className={`feedback-button ${feedback === false && 'icon-inverted'}`}
+                className={`feedback-button ${
+                  feedback === false && 'icon-inverted'
+                }`}
                 aria-label="Negative feedback"
                 id="negative-feedback"
               >
@@ -93,20 +103,34 @@ function SupportFooter({ location }) {
           </div>
           {/* second column - submit issues and make contribution */}
           <div className="support-footer__second-column">
-            <p className="support-footer__sub-title">Help make our docs better</p>
+            <p className="support-footer__sub-title">
+              Help make our docs better
+            </p>
             <ul>
               <li>
-                <a href={GITHUB_SUBMIT_ISSUES_LINK} target="_blank" rel="noopener noreferrer">
+                <a
+                  href={OVERTURE_DOCUMENTATION_SUPPORT_LINK}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
                   Submit an issue
                 </a>
               </li>
               <li>
-                <a href={GITHUB_REQUEST_FEATURES_LINK} target="_blank" rel="noopener noreferrer">
+                <a
+                  href={OVERTURE_DOCUMENTATION_CONTRIBUTION_LINK}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
                   Submit a feature request
                 </a>
               </li>
               <li>
-                <a href={contributionURL} target="_blank" rel="noopener noreferrer">
+                <a
+                  href={OVERTURE_DOCUMENTATION_CONTRIBUTION_LINK}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
                   Make a contribution
                 </a>
               </li>
@@ -115,25 +139,41 @@ function SupportFooter({ location }) {
           {/* third column - slack link */}
           <div className="support-footer__third-column">
             <p className="support-footer__sub-title">Still need help?</p>
-            <Link to={SLACK_LINK}>Ask us on Slack</Link>
+            <Link to={OVERTURE_GITHUB_LINK}>
+              Check out our GitHub Discussion Forum
+            </Link>
           </div>
           {/* joint column - second and third column*/}
           <div className="support-footer__joint-second-third-column">
             <div className="support-footer__joint-second-column">
-              <p className="support-footer__sub-title">Help make our docs better</p>
+              <p className="support-footer__sub-title">
+                Help make our docs better
+              </p>
               <ul>
                 <li>
-                  <a href={GITHUB_SUBMIT_ISSUES_LINK} target="_blank" rel="noopener noreferrer">
+                  <a
+                    href={OVERTURE_DOCUMENTATION_SUPPORT_LINK}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
                     Submit an issue
                   </a>
                 </li>
                 <li>
-                  <a href={GITHUB_REQUEST_FEATURES_LINK} target="_blank" rel="noopener noreferrer">
+                  <a
+                    href={OVERTURE_DOCUMENTATION_SUPPORT_LINK}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
                     Submit a feature request
                   </a>
                 </li>
                 <li>
-                  <a href={contributionURL} target="_blank" rel="noopener noreferrer">
+                  <a
+                    href={OVERTURE_DOCUMENTATION_CONTRIBUTION_LINK}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
                     Make a contribution
                   </a>
                 </li>
@@ -142,7 +182,9 @@ function SupportFooter({ location }) {
             {/* third column - slack link */}
             <div className="support-footer__joint-third-column">
               <p className="support-footer__sub-title">Still need help?</p>
-              <Link to={SLACK_LINK}>Ask us on Slack</Link>
+              <Link to={OVERTURE_GITHUB_DISSCUSSION_LINK}>
+                Ask us on GitHub
+              </Link>
             </div>
           </div>
         </div>

--- a/src/pages/about-us/index.js
+++ b/src/pages/about-us/index.js
@@ -13,11 +13,13 @@ import {
 } from 'components';
 import {
   OVERTURE_GITHUB_LINK,
-  GITHUB_ISSUES_LINK,
-  SLACK_LINK,
   GI_PROGRAM_LINK,
 } from 'constants/external-links';
 import './styles.scss';
+import {
+  OVERTURE_DOCUMENTATION_CONTRIBUTION_LINK,
+  OVERTURE_DOCUMENTATION_SUPPORT_LINK,
+} from '../../../constants/external-links';
 
 const AboutUsPage = () => {
   return (
@@ -53,8 +55,8 @@ const AboutUsPage = () => {
               <P2>
                 We are the{' '}
                 <Link to={GI_PROGRAM_LINK}>
-                  Genome Informatics Software Engineering team from Ontario Institute for Cancer
-                  Research
+                  Genome Informatics Software Engineering team from Ontario
+                  Institute for Cancer Research
                 </Link>
                 . At OICR we develop new software, databases and other necessary
                 components to store, organize and compute over the large and
@@ -136,16 +138,16 @@ const AboutUsPage = () => {
             {/* yellow button div */}
             <div className="grey-section__yellow-button-holder">
               <YellowButton
-                link={SLACK_LINK}
-                img_src="slackJoin"
-                alt="Join Us on Slack"
-                title="Join Us on Slack"
+                link={OVERTURE_DOCUMENTATION_CONTRIBUTION_LINK}
+                img_src="githubYellow"
+                alt="Get Involved"
+                title="Get Involved"
               />
               <YellowButton
-                link={OVERTURE_GITHUB_LINK}
+                link={OVERTURE_DOCUMENTATION_SUPPORT_LINK}
                 img_src="githubFindUs"
-                alt="Find Us on Github"
-                title="Find Us on Github"
+                alt="Get in touch"
+                title="Get in Touch"
               ></YellowButton>
             </div>
           </div>

--- a/src/pages/getting-started/index.js
+++ b/src/pages/getting-started/index.js
@@ -4,7 +4,6 @@ import {
   H2,
   H3,
   P3,
-  Search,
   YellowButton,
   LinkHelper as Link,
   Terminal,
@@ -14,23 +13,12 @@ import {
   NoteBox,
 } from 'components';
 import img_overtureQuickstartPortal from './assets/overtureQuickstartPortal.webp';
-import {
-  OVERTURE_GITHUB_LINK,
-  SLACK_LINK,
-  DOCKER_DOWNLOAD,
-} from 'constants/external-links';
+import { DOCKER_DOWNLOAD } from 'constants/external-links';
 import './styles.scss';
-import {
-  ADMINISTRATION_GUIDE,
-  DEPLOYMENT_GUIDE,
-  DOWNLOAD_GUIDE,
-  SUBMISSION_GUIDE,
-} from '../../../constants/pages';
 import {
   ADMINISTRATION_GUIDES,
   API_REFERENCE_GUIDE,
   DEPLOYMENT_GUIDES,
-  FEATURE_REQUESTS,
   OVERTURE_DOCUMENTATION_CONTRIBUTION_LINK,
   OVERTURE_DOCUMENTATION_CORE_SOFTWARE,
   OVERTURE_DOCUMENTATION_UNDER_DEVELOPMENT,
@@ -59,7 +47,7 @@ export default function GettingStartedPage() {
         <div className="container">
           <div className="upper-grey-section__holder">
             <div className="upper-grey-section__title-holder">
-              <H2>Getting Started</H2>
+              <H2>Run our QuickStart</H2>
             </div>
             <div className="upper-grey-section__content-holder">
               {/* The img holding div below displays in mobile/tablet view.*/}

--- a/src/pages/getting-started/index.js
+++ b/src/pages/getting-started/index.js
@@ -26,7 +26,17 @@ import {
   DOWNLOAD_GUIDE,
   SUBMISSION_GUIDE,
 } from '../../../constants/pages';
-import { FEATURE_REQUESTS } from '../../../constants/external-links';
+import {
+  ADMINISTRATION_GUIDES,
+  API_REFERENCE_GUIDE,
+  DEPLOYMENT_GUIDES,
+  FEATURE_REQUESTS,
+  OVERTURE_DOCUMENTATION_CONTRIBUTION_LINK,
+  OVERTURE_DOCUMENTATION_CORE_SOFTWARE,
+  OVERTURE_DOCUMENTATION_UNDER_DEVELOPMENT,
+  OVERTURE_GITHUB_DISSCUSSION_LINK,
+  USER_GUIDES,
+} from '../../../constants/external-links';
 
 export default function GettingStartedPage() {
   const docsSearchIndex = process.env.GATSBY_ALGOLIA_INDEX_NAME;
@@ -136,9 +146,6 @@ export default function GettingStartedPage() {
               </P2>
             </div>
           </div>
-          <div className="search-bar">
-            <Search indices={searchIndices} />
-          </div>
 
           <div className="text-section">
             <H3>Platform Guides</H3>
@@ -151,84 +158,66 @@ export default function GettingStartedPage() {
           <div className="list-section">
             <ul className="doc-column">
               <li className="bullet-item">
-                <a href={DEPLOYMENT_GUIDE}>Deployment:</a> generalized
-                instructions for deploying our platform from start to finish
+                {' '}
+                <a href={USER_GUIDES}>User guides:</a> stepwise guides covering
+                platform usage.
               </li>
               <li className="bullet-item">
                 {' '}
-                <a href={SUBMISSION_GUIDE}>Submission:</a>stepwise instructions
-                on submitting data to our platform
+                <a href={ADMINISTRATION_GUIDES}>Administration:</a> detailed
+                stepwise instructions for customizing our platform.
+              </li>
+              <li className="bullet-item">
+                <a href={DEPLOYMENT_GUIDES}>Deployment:</a> generalized
+                instructions for deploying our platform from start to finish.
               </li>
               <li className="bullet-item">
                 {' '}
-                <a href={DOWNLOAD_GUIDE}>Download:</a> stepwise instructions on
-                downloading data from our platform
-              </li>
-              <li className="bullet-item">
-                {' '}
-                <a href={ADMINISTRATION_GUIDE}>Administration:</a> detailed
-                stepwise instructions for customizing your platform
+                <a href={API_REFERENCE_GUIDE}>API Reference:</a> explore
+                endpoints, request parameters and response schemas through a
+                Swagger UI.
               </li>
             </ul>
           </div>
 
-          <div>
-            <div className="text-section">
-              <H3>Product Documentation</H3>
-              <P2>
-                Detailed product documentation for administrators and developers
-              </P2>
-            </div>
-            <div className="upper-grey-section__docs-holder">
-              <div className="list-columns">
-                {/* User Documentation bullets left */}
-                <div>
-                  <ul>
-                    <li className="bullet-item">
-                      <Link to="/documentation/ego">Ego:</Link> authentication
-                      and authorization for users and applications
-                    </li>
-                    <li className="bullet-item">
-                      <Link to="/documentation/song">Song:</Link> data
-                      management with automated submission validations
-                    </li>
-                    <li className="bullet-item">
-                      <Link to="/documentation/score">Score:</Link> secure
-                      multipart file transfers to and from object storage
-                    </li>
-                  </ul>
-                </div>
-                {/* User Documentation bullets right */}
-                <div>
-                  <ul>
-                    <li className="bullet-item">
-                      <Link to="/documentation/maestro">Maestro: </Link>
-                      indexes published Song metadata into Elastisearch
-                    </li>
-                    <li className="bullet-item">
-                      <Link to="/documentation/arranger">Arranger: </Link>
-                      search API generation with customizable UI component
-                      library
-                    </li>
-                    <li className="bullet-item">
-                      <Link to="/documentation/stage">Stage: </Link>
-                      react-based portal UI made to integrate with Overture
-                      services
-                    </li>
-                  </ul>
-                </div>
-              </div>
-            </div>
+          <div className="text-section">
+            <H3>Developer Documentation</H3>
+            <P2>
+              Detailed product documentation for administrators and developers
+            </P2>
           </div>
+
+          <div className="list-section">
+            <ul className="doc-column">
+              <li className="bullet-item">
+                {' '}
+                <a href={OVERTURE_DOCUMENTATION_CORE_SOFTWARE}>
+                  Core Software:
+                </a>{' '}
+                documentation covering the core components of the Overture
+                platform.
+              </li>
+              <li className="bullet-item">
+                {' '}
+                <a href={OVERTURE_DOCUMENTATION_UNDER_DEVELOPMENT}>
+                  Under Development:
+                </a>{' '}
+                new components not quite ready for production.
+              </li>
+            </ul>
+          </div>
+
           <div>
             <NoteBox
               icon="notes2"
               title="Help us make our docs better"
               className="getting-started-notebox"
             >
-              If you can't find what you are looking for, please submit{' '}
+              If you can't find what you are looking for, please let us know{' '}
               <b>
-                <Link to={FEATURE_REQUESTS}>a GitHub request</Link>
+                <Link to={OVERTURE_GITHUB_DISSCUSSION_LINK}>
+                  using our ideas discussion forum.
+                </Link>
               </b>
             </NoteBox>
           </div>
@@ -257,16 +246,16 @@ export default function GettingStartedPage() {
             </div>
             <div className="lower-grey-section__yellow-buttons-holder">
               <YellowButton
-                link={SLACK_LINK}
-                img_src="slackJoin"
-                alt="Join Us on Slack"
-                title="Join Us on Slack"
+                link={OVERTURE_DOCUMENTATION_CONTRIBUTION_LINK}
+                img_src="githubYellow"
+                alt="Get Involved"
+                title="Get Involved"
               />
               <YellowButton
-                link={OVERTURE_GITHUB_LINK}
+                link={OVERTURE_GITHUB_DISSCUSSION_LINK}
                 img_src="githubFindUs"
-                alt="Find Us on Github"
-                title="Find Us on Github"
+                alt="Reach Out"
+                title="Reach Out"
               ></YellowButton>
             </div>
           </div>

--- a/src/pages/services/index.js
+++ b/src/pages/services/index.js
@@ -36,7 +36,7 @@ const ServicesPage = () => {
         list1="Technical audits"
         list2="Step-by-step guidance"
         list3="Troubleshooting"
-        buttonText="Contact us on Slack"
+        buttonText="Community Supports"
         contactMessage="or email us at contact@overture.bio"
       />
       {/* grey section */}


### PR DESCRIPTION
## Bridge website update

- Updated NavBar with link to new docs site
- Removed all mentions of Slack, replaced with appropriate links (Github Discussion, Support page, Contribution page
- Updated getting started page to link and mirror docs site structure and resources
- General cleanup