### PR TITLE
Removing Algolia 

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -140,17 +140,17 @@ module.exports = {
       },
     },
     'gatsby-plugin-netlify',
-    {
-      resolve: 'gatsby-plugin-algolia',
-      options: {
-        apiKey: process.env.ALGOLIA_ADMIN_API_KEY,
-        appId: process.env.GATSBY_ALGOLIA_APP_ID,
-        chunkSize: 10000, // default 1000
-        indexName: process.env.GATSBY_ALGOLIA_INDEX_NAME, // for all queries
-        queries: require('./meta/algolia-queries.js'),
-        skipIndexing: !ENABLE_SEARCH_INDEXING,
-      },
-    },
+    // {
+    //   resolve: 'gatsby-plugin-algolia',
+    //   options: {
+    //     apiKey: process.env.ALGOLIA_ADMIN_API_KEY,
+    //     appId: process.env.GATSBY_ALGOLIA_APP_ID,
+    //     chunkSize: 10000, // default 1000
+    //     indexName: process.env.GATSBY_ALGOLIA_INDEX_NAME, // for all queries
+    //     queries: require('./meta/algolia-queries.js'),
+    //     skipIndexing: !ENABLE_SEARCH_INDEXING,
+    //   },
+    // },
     {
       resolve: 'gatsby-plugin-anchor-links',
       options: {


### PR DESCRIPTION
Production builds failing due to vestigial Algolia plugin, this PR aims to clean up unnecessary Algolia configs

Netlify build was successful uncertain of production build only one way to know currently, if this fails I'll need to spend some time figuring out how to use the weird QA build on my local