### PR TITLE
docker version update

### DIFF
--- a/src/pages/getting-started/index.js
+++ b/src/pages/getting-started/index.js
@@ -62,7 +62,7 @@ export default function GettingStartedPage() {
                 <P2 className="text-section">
                   <b>
                     1. Download and configure{' '}
-                    <Link to={DOCKER_DOWNLOAD}>Docker Desktop (4.32.0+)</Link>
+                    <Link to={DOCKER_DOWNLOAD}>Docker Desktop (4.39.0+)</Link>
                   </b>
                 </P2>
 

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -398,7 +398,7 @@ export default function HomePage() {
                         target="_blank"
                         rel="noopener noreferrer"
                       >
-                        Docker Desktop (4.32.0+)
+                        Docker Desktop (4.39.0+)
                       </a>
                     </b>
                   </P2>


### PR DESCRIPTION
Updated docker version req to 4.39.0+ due to [docker JVM issue](https://github.com/docker/for-mac/issues/7573) resolved by dockers latest release https://docs.docker.com/desktop/release-notes/#4380