### PR TITLE
added support link to navbar

### DIFF
--- a/constants/external-links.js
+++ b/constants/external-links.js
@@ -24,6 +24,7 @@ export const OVERTURE_DOCUMENTATION_UNDER_DEVELOPMENT =
   'https://docs.overture.bio/docs/under-development/';
 export const OVERTURE_DOCUMENTATION_LICENSING =
   'https://docs.overture.bio/community/licensing';
+export const OVERTURE_SUPPORT = 'https://docs.overture.bio/community/support';
 
 // Case Study Links
 

--- a/src/components/NavBar/index.js
+++ b/src/components/NavBar/index.js
@@ -18,6 +18,7 @@ import './styles.scss';
 import {
   DOCUMENTATION_LINK,
   OVERTURE_GITHUB_LINK,
+  OVERTURE_SUPPORT,
 } from '../../../constants/external-links';
 
 class NavBar extends Component {
@@ -80,6 +81,11 @@ class NavBar extends Component {
                 closeMenus={closeMenus}
                 url={ABOUT_US_PATH}
                 name="About Us"
+              />
+              <NavLink
+                closeMenus={closeMenus}
+                url={OVERTURE_SUPPORT}
+                name="Support"
               />
             </div>
             {/* grey section with three cubes */}


### PR DESCRIPTION
Users were having trouble finding our support page, in addition to ensuring they are linked within the readmes I am updating the navbar on overture.bio to link directly to our support page